### PR TITLE
✨ feat : 음원의 파형을 Fourier transform후 시각화하는 코드

### DIFF
--- a/utils/fourier_tf.py
+++ b/utils/fourier_tf.py
@@ -1,0 +1,25 @@
+import numpy as np
+import matplotlib.pyplot as plt
+import librosa
+
+# 오디오 파일 로드
+audio_path = "../../pianosound/Can't_Help_Falling_In_Love.wav"
+y, sr = librosa.load(audio_path)
+
+# 푸리에 변환 수행
+fft_result = np.fft.fft(y)
+magnitude = np.abs(fft_result)  # 진폭 스펙트럼 계산
+frequency = np.linspace(0, sr, len(magnitude))  # 주파수 축 생성
+
+# 주파수 축을 절반으로 줄이기 (나이퀴스트 주파수 이상은 의미 없음)
+half_frequency = frequency[: len(frequency) // 2]
+half_magnitude = magnitude[: len(magnitude) // 2]
+
+# 주파수 스펙트럼 시각화
+plt.figure(figsize=(10, 5))
+plt.plot(half_frequency, half_magnitude)
+plt.title("Frequency Domain")
+plt.xlabel("Frequency (Hz)")
+plt.ylabel("Magnitude")
+plt.grid()
+plt.show()


### PR DESCRIPTION
## 개요
- 음원파일에 Fourier transform을 적용하고 시각화로 확인할 수 있는 코드
## 작업 사항
- librosa, numpy, matplolib 라이브러리 활용
- 음원파일을 직접 로드하여 푸리에 변환 수행
- 주파수 스펙트럼을 시각화
## 스크린샷
![image](https://github.com/DorianYellow/PenguinMan/assets/146207162/7e6a7505-ec4e-4659-9754-1398e6419ca4)

## issue
- close #10 